### PR TITLE
Change bool type & fix test file

### DIFF
--- a/nulls/null_bool.go
+++ b/nulls/null_bool.go
@@ -35,20 +35,25 @@ func (ns NullBool) Value() (driver.Value, error) {
 // MarshalJSON marshals the underlying value to a
 // proper JSON representation.
 func (ns NullBool) MarshalJSON() ([]byte, error) {
-	return json.Marshal(ns.Bool)
+	if ns.Valid {
+		return json.Marshal(ns.Bool)
+	}
+	return json.Marshal(nil)
 }
 
 // UnmarshalJSON will unmarshal a JSON value into
-// the propert representation of that value. The strings
+// the proper representation of that value. The strings
 // "true" and "t" will be considered "true", all other
-// values will be considered "false".
+// values will be considered "false". Null values will
+//be set by setting Valid = false
 func (ns *NullBool) UnmarshalJSON(text []byte) error {
 	t := string(text)
-	ns.Valid = true
-	ns.Bool = false
 	if t == "true" || t == "t" {
+		ns.Valid = true
 		ns.Bool = true
 		return nil
 	}
+	ns.Bool = false
+	ns.Valid = false
 	return nil
 }

--- a/nulls/null_types_test.go
+++ b/nulls/null_types_test.go
@@ -82,7 +82,7 @@ func TestNullTypesMarshalProperly(t *testing.T) {
 	assert.Equal(f.Bytes.ByteSlice, ba)
 	assert.Equal(f.IntType.Int, 2)
 	assert.Equal(f.Int32Type.Int32, 3)
-	assert.Equal(f.UInt32Type.UInt32, 5)
+	assert.Equal(f.UInt32Type.UInt32, uint32(5))
 
 	// check marshalling nulls works:
 	f = Foo{}
@@ -110,7 +110,7 @@ func TestNullTypesMarshalProperly(t *testing.T) {
 	assert.False(f.IntType.Valid)
 	assert.Equal(f.Int32Type.Int32, 0)
 	assert.False(f.Int32Type.Valid)
-	assert.Equal(f.UInt32Type.UInt32, 0)
+	assert.Equal(f.UInt32Type.UInt32, uint32(0))
 	assert.False(f.UInt32Type.Valid)
 }
 
@@ -151,7 +151,7 @@ func TestNullTypeSaveAndRetrieveProperly(t *testing.T) {
 		assert.Equal(f.Bytes.ByteSlice, []byte(nil))
 		assert.Equal(f.IntType.Int, 0)
 		assert.Equal(f.Int32Type.Int32, 0)
-		assert.Equal(f.UInt32Type.UInt32, 0)
+		assert.Equal(f.UInt32Type.UInt32, uint32(0))
 		tx.Rollback()
 
 		tx, err = db.Beginx()
@@ -180,7 +180,7 @@ func TestNullTypeSaveAndRetrieveProperly(t *testing.T) {
 		assert.Equal(f.Bytes.ByteSlice, []byte("Byte Slice"))
 		assert.Equal(f.IntType.Int, 2)
 		assert.Equal(f.Int32Type.Int32, 3)
-		assert.Equal(f.UInt32Type.UInt32, 5)
+		assert.Equal(f.UInt32Type.UInt32, uint32(5))
 
 		tx.Rollback()
 	})


### PR DESCRIPTION
NullBool now sets Valid = false when a null value is encountered and is
marshaled to null when Valid = false. Also, for NullUInt32 I had to
cast test values w/ uint32 in the test file. They were being
represented as hexadecimal. This behavior didn’t occur before Go 1.4.