### PR TITLE
Fix typo(s) and links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@ This project houses, what I consider to be some help packages for writing Go app
 
 ## Packages
 
-* [nulls](http://github.com/markbates/going/nulls) - Proper JSON implementations of `null` database types.
-* [validate](http://github.com/markbates/going/validate) - A framework for writing validations.
-* [wait](http://github.com/markbates/going/wait) - Wait cleans up the pattern around using `sync.WaitGroup`.
-* [defaults](http://github.com/markbates/going/defaults) - Allows for the setting of default values for common types.
-* [chalk](http://github.com/markbates/going/chalk) - Quickly and easily create a pool of `go routines`.
-* [willie](http://github.com/markbates/going/willie) - A helper for cleaning up HTTP tests.
-* [del](http://github.com/markbates/going/del) - A wrapper around the [render](https://github.com/unrolled/render) package to make it work with [echo](https://github.com/labstack/echo).
+* [nulls](./nulls) - Proper JSON implementations of `null` database types.
+* [validate](./validate) - A framework for writing validations.
+* [wait](./wait) - Wait cleans up the pattern around using `sync.WaitGroup`.
+* [defaults](./defaults) - Allows for the setting of default values for common types.
+* [willy](./willy) - A helper for cleaning up HTTP tests.
+* [del](./del) - A wrapper around the [render](https://github.com/unrolled/render) package to make it work with [echo](https://github.com/labstack/echo).
 


### PR DESCRIPTION
* Links were leading to 404s. Made them relative.
* Removed the "chalk" reference that seems to have been replaced by the "wait" package.